### PR TITLE
Fix for update to not generate garbage

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/GraphyDebugger.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/GraphyDebugger.cs
@@ -356,8 +356,6 @@ namespace Tayx.Graphy
         /// </summary>
         private void CheckDebugPackets()
         {
-            List<DebugPacket> debugPacketsToRemove = new List<DebugPacket>();
-
             foreach (DebugPacket packet in m_debugPackets)
             {
                 if (packet.Active)
@@ -385,7 +383,7 @@ namespace Tayx.Graphy
 
                                     if (packet.ExecuteOnce)
                                     {
-                                        debugPacketsToRemove.Add(packet);
+                                        m_debugPackets[m_debugPackets.IndexOf(packet)] = null;
                                     }
                                 }
                                 break;
@@ -399,7 +397,7 @@ namespace Tayx.Graphy
 
                                         if (packet.ExecuteOnce)
                                         {
-                                            debugPacketsToRemove.Add(packet);
+                                            m_debugPackets[m_debugPackets.IndexOf(packet)] = null;
                                         }
 
                                         break;
@@ -411,10 +409,7 @@ namespace Tayx.Graphy
                 }
             }
 
-            foreach (var packetToRemove in debugPacketsToRemove)
-            {
-                m_debugPackets.Remove(packetToRemove);
-            }
+            m_debugPackets.RemoveAll((packet) => packet == null);
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed the `Update()` method was generating 32B of garbage per frame.  Clearly this cannot stand.  I'm lucky my computer was able to survive such an onslaught.

This should allow 0B of garbage allocation per frame.