### PR TITLE
Do not update parameters if Graphy is inactive

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/GraphyManager.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/GraphyManager.cs
@@ -366,7 +366,7 @@ namespace Tayx.Graphy
         {
             m_focused = isFocused;
 
-            if (m_initialized && isFocused)
+            if (m_initialized && isFocused && m_active)
             {
                 UpdateAllParameters();
             }


### PR DESCRIPTION
Hello,

I am experiencing issues with focus change. (Editor, Windows Standalone, iOS)

How to reproduce:
1. Open graphy in Unity (my version is 2017.4.14f1 LTS)
2. Create new scene
3. Drag [Graphy] prefab into scene
4. Uncheck Enable On Startup
5. Press Play (Graphy will not show up as expected)
6. Press somewhere outside the Unity Editor (Windows Taskbar for example)
7. Return focus to the Unity Editor (still in play mode)
8. Graphy will appear (BUG)

Expected behavior: graphy should stay hidden.

This pull request should resolve the issue.