### PR TITLE
Add null check for Audio Listener ref

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioMonitor.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioMonitor.cs
@@ -188,7 +188,8 @@ namespace Tayx.Graphy.Audio
 
             SceneManager.sceneLoaded += (scene, loadMode) =>
             {
-                if (m_findAudioListenerInCameraIfNull == GraphyManager.LookForAudioListener.ON_SCENE_LOAD)
+                if (m_audioListener == null
+                    && m_findAudioListenerInCameraIfNull == GraphyManager.LookForAudioListener.ON_SCENE_LOAD)
                 {
                     FindAudioListener();
                 }


### PR DESCRIPTION
Without this check, existing code will try to override the audio listener from the main camera.