### PR TITLE
Add support for VR Single Pass Instanced Rendering

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Shaders/GraphStandard.shader
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Shaders/GraphStandard.shader
@@ -47,6 +47,7 @@
 					float4 vertex    : POSITION;
 					float4 color     : COLOR;
 					float2 texcoord  : TEXCOORD0;
+					UNITY_VERTEX_INPUT_INSTANCE_ID
 				};
 
 				struct v2f
@@ -54,6 +55,7 @@
 					float4 vertex    : SV_POSITION;
 					fixed4 color	 : COLOR;
 					float2 texcoord  : TEXCOORD0;
+					UNITY_VERTEX_OUTPUT_STEREO
 				};
 
 				fixed4 _Color;
@@ -61,6 +63,10 @@
 				v2f vert(appdata_t IN)
 				{
 					v2f OUT;
+					UNITY_SETUP_INSTANCE_ID(IN);
+					UNITY_INITIALIZE_OUTPUT(v2f, OUT);
+					UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(OUT);
+
 					OUT.vertex = UnityObjectToClipPos(IN.vertex);
 					OUT.texcoord = IN.texcoord;
 					OUT.color = IN.color * _Color;


### PR DESCRIPTION
Graphy previously only rendered to one eye when running in VR with
Single Pass Instanced Rendering. Fixed by slight modification to the
standard shader.
See: https://docs.unity3d.com/Manual/SinglePassInstancing.html

Tested and Verified on Oculus Rift S.