### PR TITLE
Prevent NullReferenceException in Editor w/ Graphy disabled.

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioGraph.cs
@@ -70,6 +70,12 @@ namespace Tayx.Graphy.Audio
 
         public void UpdateParameters()
         {
+            if (m_shaderGraph == null)
+            {
+                // TODO: While Graphy is disabled (e.g. by default via Ctrl+H) and while in Editor after a Hot-Swap,
+                // the OnApplicationFocus calls this while m_shaderGraph == null, throwing a NullReferenceException
+                return;
+            }
             switch (m_graphyManager.GraphyMode)
             {
                 case GraphyManager.Mode.FULL:

--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Fps/G_FpsGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Fps/G_FpsGraph.cs
@@ -66,6 +66,12 @@ namespace Tayx.Graphy.Fps
         
         public void UpdateParameters()
         {
+            if (m_shaderGraph == null)
+            {
+                // TODO: While Graphy is disabled (e.g. by default via Ctrl+H) and while in Editor after a Hot-Swap,
+                // the OnApplicationFocus calls this while m_shaderGraph == null, throwing a NullReferenceException
+                return;
+            }
             switch (m_graphyManager.GraphyMode)
             {
                 case GraphyManager.Mode.FULL:


### PR DESCRIPTION
Prevented NullReferenceException from OnApplicationFocus after
Hot-Swap in Editor when Graphy is Disabled.