### PR TITLE
Issue 17 Fix

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioGraph.cs
@@ -31,6 +31,9 @@ namespace Tayx.Graphy.Audio
         [SerializeField] private    Shader          ShaderFull = null;
         [SerializeField] private    Shader          ShaderLight = null;
 
+        // This keeps track of whether Init() has run or not
+        [SerializeField] private    bool            m_isInitialized = false;
+
         #endregion
 
         #region Variables -> Private
@@ -50,11 +53,6 @@ namespace Tayx.Graphy.Audio
         #endregion
 
         #region Methods -> Unity Callbacks
-
-        private void OnEnable()
-        {
-            Init();
-        }
 
         private void Update()
         {
@@ -109,6 +107,13 @@ namespace Tayx.Graphy.Audio
 
         protected override void UpdateGraph()
         {
+            // Since we no longer initialize by default OnEnable(), 
+            // we need to check here, and Init() if needed
+            if (!m_isInitialized)
+            {
+                Init();
+            }
+
             int incrementPerIteration = Mathf.FloorToInt(m_audioMonitor.Spectrum.Length / (float)m_resolution);
 
             // Current values -------------------------
@@ -262,6 +267,8 @@ namespace Tayx.Graphy.Audio
             };
 
             UpdateParameters();
+
+            m_isInitialized = true;
         }
 
         #endregion

--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Audio/G_AudioGraph.cs
@@ -54,6 +54,25 @@ namespace Tayx.Graphy.Audio
 
         #region Methods -> Unity Callbacks
 
+        private void OnEnable()
+        {
+            /* ----- NOTE: ----------------------------
+             * We used to Init() here regardless of
+             * whether this module was enabled.
+             * The reason we don't Init() here
+             * anymore is that some users are on 
+             * platforms that do not support the arrays 
+             * in the Shaders.
+             *
+             * See: https://github.com/Tayx94/graphy/issues/17
+             * 
+             * Even though we don't Init() competely
+             * here anymore, we still need 
+             * m_audioMonitor for in Update()
+             * --------------------------------------*/
+            m_audioMonitor = GetComponent<G_AudioMonitor>();
+        }
+
         private void Update()
         {
             if (m_audioMonitor.SpectrumDataAvailable)

--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Fps/G_FpsGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Fps/G_FpsGraph.cs
@@ -31,7 +31,7 @@ namespace Tayx.Graphy.Fps
         [SerializeField] private    Shader          ShaderLight = null;
 
         // This keeps track of whether Init() has run or not
-        [SerializeField] private bool               m_isInitialized = false;
+        [SerializeField] private    bool            m_isInitialized = false;
 
         #endregion
 

--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Fps/G_FpsGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Fps/G_FpsGraph.cs
@@ -30,6 +30,9 @@ namespace Tayx.Graphy.Fps
         [SerializeField] private    Shader          ShaderFull = null;
         [SerializeField] private    Shader          ShaderLight = null;
 
+        // This keeps track of whether Init() has run or not
+        [SerializeField] private bool               m_isInitialized = false;
+
         #endregion
 
         #region Variables -> Private
@@ -49,11 +52,6 @@ namespace Tayx.Graphy.Fps
         #endregion
 
         #region Methods -> Unity Callbacks
-
-        private void OnEnable()
-        {
-            Init();
-        }
 
         private void Update()
         {
@@ -98,6 +96,13 @@ namespace Tayx.Graphy.Fps
 
         protected override void UpdateGraph()
         {
+            // Since we no longer initialize by default OnEnable(), 
+            // we need to check here, and Init() if needed
+            if (!m_isInitialized)
+            {
+                Init();
+            }
+            
             int fps = (int)(1 / Time.unscaledDeltaTime);
 
             int currentMaxFps = 0;
@@ -185,6 +190,8 @@ namespace Tayx.Graphy.Fps
             };
 
             UpdateParameters();
+
+            m_isInitialized = true;
         }
 
         #endregion

--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Ram/G_RamGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Ram/G_RamGraph.cs
@@ -73,12 +73,22 @@ namespace Tayx.Graphy.Ram
         #region Methods -> Public
 
         public void UpdateParameters()
-        {
+        { 
             if (    m_shaderGraphAllocated  == null
                 ||  m_shaderGraphReserved   == null
                 ||  m_shaderGraphMono       == null)
             {
-                Init();
+                /*
+                 * Note: this is fine, since we don't much
+                 * care what granularity we use if the graph
+                 * has not been initialized, i.e. it's disabled.
+                 * There is no chance that for some reason 
+                 * parameters will not stay up to date if
+                 * at some point in the future the graph is enabled:
+                 * at the end of Init(), UpdateParameters() is
+                 * called again.
+                 */
+                return;
             }
              
             switch (m_graphyManager.GraphyMode)

--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Ram/G_RamGraph.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Ram/G_RamGraph.cs
@@ -36,6 +36,9 @@ namespace Tayx.Graphy.Ram
         [SerializeField] private    Shader          ShaderFull = null;
         [SerializeField] private    Shader          ShaderLight = null;
 
+        // This keeps track of whether Init() has run or not
+        [SerializeField] private    bool            m_isInitialized = false;
+
         #endregion
 
         #region Variables -> Private
@@ -59,11 +62,6 @@ namespace Tayx.Graphy.Ram
         #endregion
 
         #region Methods -> Unity Callbacks
-
-        private void OnEnable()
-        {
-            Init();
-        }
 
         private void Update()
         {
@@ -121,6 +119,13 @@ namespace Tayx.Graphy.Ram
 
         protected override void UpdateGraph()
         {
+            // Since we no longer initialize by default OnEnable(), 
+            // we need to check here, and Init() if needed
+            if (!m_isInitialized)
+            {
+                Init();
+            }
+
             float allocatedMemory   = m_ramMonitor.AllocatedRam;
             float reservedMemory    = m_ramMonitor.ReservedRam;
             float monoMemory        = m_ramMonitor.MonoRam;
@@ -252,6 +257,8 @@ namespace Tayx.Graphy.Ram
             m_shaderGraphMono       .Image = m_imageMono;
             
             UpdateParameters();
+
+            m_isInitialized = true;
         }
 
         #endregion


### PR DESCRIPTION
Hey,

I think this fixes Issue 17: https://github.com/Tayx94/graphy/issues/17 

G_RamGraph, G_AudioGraph, and G_FpsGraph are now only initialized and updated if the user has the corresponding module set to "FULL". It also works to start out with the module disabled, and then enable it later. Init() will only be called when you first change the module state to "FULL". 

For each of the G_Graphs, Init() is not called in OnEnable() anymore. Instead, Init() is called the first time UpdateGraph() is called. This ensures that the graphs are only initialized or updated if the user actually wants them to be. I think this should prevent the Shader errors mentioned in the issue, as the G_GraphShader each of these classes has never gets initialized if the module state is never "FULL".

I'm not sure what the project testing standards are - I tested each of the G_Graphs with print statements in Init() and UpdateGraph(). The new behavior seems correct: 
- If I start with a module state set to "OFF" or another state that doesn't need the graph, Init() and UpdateGraph() never run. 
- If I start with a module state set to "FULL", Init() runs once, and then UpdateGraph() runs every frame from then on.
- If I start with a module state set to "OFF" or another state that doesn't need the graph, Init() and UpdateGraph() initially don't run. After I change the module state to "FULL", the graph activates properly. 

I also made sure it all still works in a PC build. I unfortunately don't have access to an iPad however, so I am not able to directly test if this works too. 

Please let me know if you have any feedback.
Cheers!