### PR TITLE
Fixed calls to OnDestroy when the singleton does get created multiple…

### DIFF
--- a/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Util/G_Singleton.cs
+++ b/Assets/Tayx/Graphy - Ultimate Stats Monitor/Scripts/Util/G_Singleton.cs
@@ -127,7 +127,10 @@ namespace Tayx.Graphy.Utils
         /// </summary>
         void OnDestroy()
         {
-            _applicationIsQuitting = true;
+            if (_instance == this)
+            {
+                _applicationIsQuitting = true;
+            }
         }
 
         #endregion


### PR DESCRIPTION
… times.

The code path is as follows:
* Load the scene that contains the singleton
* Unload the scene that contains the singleton (it's marked as DontDestroyOnLoad so it won't make a difference)
* Load the scene that contains the singleton again
* Notice that in the Awake, _instance != null so we call Destroy
* We've just marked our Singleton as _applicationIsQuitting, which is totally not the case.
* The initial singleton is still alive, but the _applicationIsQuitting flag is set so we can no longer access it.

The fix I made ensures that we only mark ourselves as quitting, when the actual singleton gets cleaned up.