### PR TITLE
Fixed advanced data multiple initialization

### DIFF
--- a/Runtime/Advanced/G_AdvancedData.cs
+++ b/Runtime/Advanced/G_AdvancedData.cs
@@ -76,7 +76,7 @@ namespace Tayx.Graphy.Advanced
 
         #region Methods -> Unity Callbacks
 
-        private void OnEnable()
+        private void Awake()
         {
             Init();
         }


### PR DESCRIPTION
Init() can be called more than once because it's placed in OnEnable(). And this actually happens when SetState() is called, because of this, SetState() didn't work correctly and did not change the state (SetState() calls SetActive() and it calls OnEnable(), and Init() "overrides" new state). Visually, you can see this problem during toggle modes when the value of advanced module state is OFF or BACKGROUND (Graphy Manager -> [Advanced Data]). In this case the Advance module will never appears.

I don't see any reason why Init() should be in OnEnable(), so I just moved Init() to Awake(), as it's done in other modules.