### PR TITLE
Make module labels clickable, not just icons.

### DIFF
--- a/Editor/GraphyManagerEditor.cs
+++ b/Editor/GraphyManagerEditor.cs
@@ -477,7 +477,8 @@ namespace Tayx.Graphy
             (
                 m_fpsModuleInspectorToggle,
                 content: " [ FPS ]",
-                style: GraphyEditorStyle.FoldoutStyle
+                style: GraphyEditorStyle.FoldoutStyle,
+                toggleOnLabelClick: true
             );
 
             GUILayout.Space( 5 );
@@ -607,7 +608,8 @@ namespace Tayx.Graphy
             (
                 m_ramModuleInspectorToggle,
                 content: " [ RAM ]",
-                style: GraphyEditorStyle.FoldoutStyle
+                style: GraphyEditorStyle.FoldoutStyle,
+                toggleOnLabelClick: true
             );
 
             GUILayout.Space( 5 );
@@ -687,7 +689,8 @@ namespace Tayx.Graphy
             (
                 m_audioModuleInspectorToggle,
                 content: " [ AUDIO ]",
-                style: GraphyEditorStyle.FoldoutStyle
+                style: GraphyEditorStyle.FoldoutStyle,
+                toggleOnLabelClick: true
             );
 
             GUILayout.Space( 5 );
@@ -822,7 +825,8 @@ namespace Tayx.Graphy
             (
                 m_advancedModuleInspectorToggle,
                 content: " [ ADVANCED DATA ]",
-                style: GraphyEditorStyle.FoldoutStyle
+                style: GraphyEditorStyle.FoldoutStyle,
+                toggleOnLabelClick: true
             );
 
             GUILayout.Space( 5 );


### PR DESCRIPTION
Made each module's label clickable for usability.

![image](https://user-images.githubusercontent.com/47441314/174526352-efd4fd77-5680-4680-a7ab-076bd964563f.png)
