### PR TITLE
Fix: replace 'TryGetComponent()' with a backwards-compatible logic

### DIFF
--- a/Runtime/Audio/G_AudioMonitor.cs
+++ b/Runtime/Audio/G_AudioMonitor.cs
@@ -180,8 +180,9 @@ namespace Tayx.Graphy.Audio
         private AudioListener FindAudioListener()
         {
             Camera mainCamera = Camera.main;
+            AudioListener audioListener;
 
-            if( mainCamera != null && mainCamera.TryGetComponent( out AudioListener audioListener ) )
+            if( mainCamera != null && ( audioListener = mainCamera.GetComponent<AudioListener>() ) != null )
             {
                 return audioListener;
             }


### PR DESCRIPTION
The method `Component.TryGetComponent()` was introduced in Unity 2019.2. Previous versions can not compile this package.

Changed the `if` branching to a compatible version in this pull request.

Cheers
Jules