### PR TITLE
fix bug of GraphyDebugger.GetRequestedValueFromDebugVariable()

### DIFF
--- a/Runtime/GraphyDebugger.cs
+++ b/Runtime/GraphyDebugger.cs
@@ -500,9 +500,9 @@ namespace Tayx.Graphy
                 case DebugVariable.Ram_Allocated:
                     return m_ramMonitor != null ? m_ramMonitor.AllocatedRam : 0;
                 case DebugVariable.Ram_Reserved:
-                    return m_ramMonitor != null ? m_ramMonitor.AllocatedRam : 0;
+                    return m_ramMonitor != null ? m_ramMonitor.ReservedRam : 0;
                 case DebugVariable.Ram_Mono:
-                    return m_ramMonitor != null ? m_ramMonitor.AllocatedRam : 0;
+                    return m_ramMonitor != null ? m_ramMonitor.MonoRam : 0;
 
                 case DebugVariable.Audio_DB:
                     return m_audioMonitor != null ? m_audioMonitor.MaxDB : 0;


### PR DESCRIPTION
Hi @Tayx94 

This PR fix the bug GraphyDebugger.GetRequestedValueFromDebugVariable() fetches the wrong values when the given 'DebugVariable' is DebugVariable.Ram_Reserved or DebugVariable.Ram_Mono and makes 'GraphyDebugger.DebugPacket' function incorrectly.