### PR TITLE
Fix: GraphyManager.OnDestroy() hides G_Singleton<T>.OnDestroy()

### DIFF
--- a/Runtime/GraphyManager.cs
+++ b/Runtime/GraphyManager.cs
@@ -547,10 +547,12 @@ namespace Tayx.Graphy
             Init();
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
             G_IntString.Dispose();
             G_FloatString.Dispose();
+
+            base.OnDestroy();
         }
 
         private void Update()

--- a/Runtime/Util/G_Singleton.cs
+++ b/Runtime/Util/G_Singleton.cs
@@ -59,7 +59,7 @@ namespace Tayx.Graphy.Utils
 
         #region Methods -> Unity Callbacks
 
-        void Awake()
+        protected virtual void Awake()
         {
             if( _instance != null )
             {
@@ -71,7 +71,7 @@ namespace Tayx.Graphy.Utils
             }
         }
 
-        void OnDestroy()
+        protected virtual void OnDestroy()
         {
             if( _instance == this )
             {


### PR DESCRIPTION
`GraphyManager` implements singleton pattern via `G_Singleton<T>`. Both have `void OnDestroy()` which is private by default. So, `GraphyManager` hides implementation of `G_Singleton<T>` implicitly. `OnDestroy()` should be made virtual to override it in the derived classes and call base implementation. This pull request makes `OnDestroy()` as `protected virtual`. `Awake()`  made `protected virtual` as well to avoid future mistakes. Compiler will warn in the case of defining `Awake()` or `Destroy()` in the derived classes without override.