### PR TITLE
Bug: Apple tvOS doesn't support XR which causes compilation issues

### DIFF
--- a/Runtime/Advanced/G_AdvancedData.cs
+++ b/Runtime/Advanced/G_AdvancedData.cs
@@ -14,7 +14,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 
-#if GRAPHY_XR
+#if GRAPHY_XR && !UNITY_TVOS
 using UnityEngine.XR;
 #endif
 
@@ -47,7 +47,7 @@ namespace Tayx.Graphy.Advanced
         [SerializeField] private Text m_gameWindowResolutionText = null;
         [SerializeField] private Text m_gameVRResolutionText = null;
         
-#if GRAPHY_XR
+#if GRAPHY_XR && !UNITY_TVOS
         private readonly List<XRDisplaySubsystem> m_displaySubsystems = new List<XRDisplaySubsystem>();
 #endif
         
@@ -120,7 +120,7 @@ namespace Tayx.Graphy.Advanced
 
                 m_gameWindowResolutionText.text = m_sb.ToString();
 
-#if GRAPHY_XR
+#if GRAPHY_XR && !UNITY_TVOS
                 // If XR enabled, update screen XR resolution
                 if( XRSettings.enabled )
                 {


### PR DESCRIPTION
I've found that tvOS target has compilation issues when XR module added to the project. XR usage is excluded via UNITY_TVOS. I saw in other 3rd-party sources that guys also exclude Xbox, PS and Nintendo Switch. But I don't have such targets in my current project to test, so I fixed only tvOS.