### PR TITLE
Conditional audio module

### DIFF
--- a/Editor/GraphyDebuggerEditor.cs
+++ b/Editor/GraphyDebuggerEditor.cs
@@ -545,8 +545,10 @@ namespace Tayx.Graphy
                 case GraphyDebugger.DebugVariable.Ram_Mono:
                     return "Ram Mono";
 
+#if GRAPHY_BUILTIN_AUDIO
                 case GraphyDebugger.DebugVariable.Audio_DB:
                     return "Audio DB";
+#endif // GRAPHY_BUILTIN_AUDIO
 
                 default:
                     return null;

--- a/Editor/GraphyManagerEditor.cs
+++ b/Editor/GraphyManagerEditor.cs
@@ -100,6 +100,7 @@ namespace Tayx.Graphy
         #endregion
 
         #region Section -> Audio
+#if GRAPHY_BUILTIN_AUDIO
 
         private bool m_audioModuleInspectorToggle = true;
 
@@ -119,6 +120,7 @@ namespace Tayx.Graphy
 
         private SerializedProperty m_spectrumSize;
 
+#endif // GRAPHY_BUILTIN_AUDIO
         #endregion
 
         #region Section -> Advanced Settings
@@ -205,6 +207,7 @@ namespace Tayx.Graphy
             #endregion
 
             #region Section -> Audio
+#if GRAPHY_BUILTIN_AUDIO
 
             m_findAudioListenerInCameraIfNull = serObj.FindProperty( "m_findAudioListenerInCameraIfNull" );
 
@@ -222,6 +225,7 @@ namespace Tayx.Graphy
 
             m_spectrumSize = serObj.FindProperty( "m_spectrumSize" );
 
+#endif // GRAPHY_BUILTIN_AUDIO
             #endregion
 
             #region Section -> Advanced Settings
@@ -681,9 +685,12 @@ namespace Tayx.Graphy
 
             #endregion
 
+#if GRAPHY_BUILTIN_AUDIO
             GUILayout.Space( 20 );
+#endif // GRAPHY_BUILTIN_AUDIO
 
             #region Section -> Audio
+#if GRAPHY_BUILTIN_AUDIO
 
             m_audioModuleInspectorToggle = EditorGUILayout.Foldout
             (
@@ -815,6 +822,7 @@ namespace Tayx.Graphy
                 );
             }
 
+#endif // GRAPHY_BUILTIN_AUDIO
             #endregion
 
             GUILayout.Space( 20 );

--- a/Editor/Tayx.Graphy.Editor.asmdef
+++ b/Editor/Tayx.Graphy.Editor.asmdef
@@ -17,6 +17,11 @@
             "name": "com.unity.inputsystem",
             "expression": "",
             "define": "GRAPHY_NEW_INPUT"
+        },
+        {
+            "name": "com.unity.modules.audio",
+            "expression": "",
+            "define": "GRAPHY_BUILTIN_AUDIO"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Audio/G_AudioGraph.cs
+++ b/Runtime/Audio/G_AudioGraph.cs
@@ -17,6 +17,9 @@ using UnityEngine.UI;
 
 namespace Tayx.Graphy.Audio
 {
+#if !GRAPHY_BUILTIN_AUDIO
+    public class G_AudioGraph : MonoBehaviour { }
+#else
     public class G_AudioGraph : G_Graph
     {
         #region Variables -> Serialized Private
@@ -291,4 +294,5 @@ namespace Tayx.Graphy.Audio
 
         #endregion
     }
+#endif // !GRAPHY_BUILTIN_AUDIO
 }

--- a/Runtime/Audio/G_AudioManager.cs
+++ b/Runtime/Audio/G_AudioManager.cs
@@ -19,6 +19,9 @@ using Tayx.Graphy.Utils;
 
 namespace Tayx.Graphy.Audio
 {
+#if !GRAPHY_BUILTIN_AUDIO
+    public class G_AudioManager : MonoBehaviour { }
+#else
     public class G_AudioManager : MonoBehaviour, IMovable, IModifiableState
     {
         #region Variables -> Serialized Private
@@ -236,4 +239,5 @@ namespace Tayx.Graphy.Audio
 
         #endregion
     }
+#endif // !GRAPHY_BUILTIN_AUDIO
 }

--- a/Runtime/Audio/G_AudioMonitor.cs
+++ b/Runtime/Audio/G_AudioMonitor.cs
@@ -23,6 +23,7 @@ namespace Tayx.Graphy.Audio
     /// </summary>
     public class G_AudioMonitor : MonoBehaviour
     {
+#if GRAPHY_BUILTIN_AUDIO
         #region Variables -> Private
 
         private const float m_refValue = 1f;
@@ -207,5 +208,6 @@ namespace Tayx.Graphy.Audio
         }
 
         #endregion
+#endif
     }
 }

--- a/Runtime/Audio/G_AudioText.cs
+++ b/Runtime/Audio/G_AudioText.cs
@@ -19,6 +19,7 @@ namespace Tayx.Graphy.Audio
 {
     public class G_AudioText : MonoBehaviour
     {
+#if GRAPHY_BUILTIN_AUDIO
         #region Variables -> Serialized Private
 
         [SerializeField] private Text m_DBText = null;
@@ -86,5 +87,6 @@ namespace Tayx.Graphy.Audio
         }
 
         #endregion
+#endif // GRAPHY_BUILTIN_AUDIO
     }
 }

--- a/Runtime/GraphyDebugger.cs
+++ b/Runtime/GraphyDebugger.cs
@@ -19,7 +19,10 @@ using Debug = UnityEngine.Debug;
 using System.Collections.Generic;
 using System.Linq;
 
+#if GRAPHY_BUILTIN_AUDIO
 using Tayx.Graphy.Audio;
+#endif // GRAPHY_BUILTIN_AUDIO
+
 using Tayx.Graphy.Fps;
 using Tayx.Graphy.Ram;
 using Tayx.Graphy.Utils;
@@ -46,7 +49,9 @@ namespace Tayx.Graphy
             Ram_Allocated,
             Ram_Reserved,
             Ram_Mono,
+#if GRAPHY_BUILTIN_AUDIO
             Audio_DB
+#endif // GRAPHY_BUILTIN_AUDIO
         }
 
         public enum DebugComparer
@@ -171,7 +176,10 @@ namespace Tayx.Graphy
 
         private G_FpsMonitor m_fpsMonitor = null;
         private G_RamMonitor m_ramMonitor = null;
+
+#if GRAPHY_BUILTIN_AUDIO
         private G_AudioMonitor m_audioMonitor = null;
+#endif // GRAPHY_BUILTIN_AUDIO
 
         #endregion
 
@@ -181,7 +189,10 @@ namespace Tayx.Graphy
         {
             m_fpsMonitor = GetComponentInChildren<G_FpsMonitor>();
             m_ramMonitor = GetComponentInChildren<G_RamMonitor>();
+
+#if GRAPHY_BUILTIN_AUDIO
             m_audioMonitor = GetComponentInChildren<G_AudioMonitor>();
+#endif // GRAPHY_BUILTIN_AUDIO
         }
 
         private void Update()
@@ -504,8 +515,10 @@ namespace Tayx.Graphy
                 case DebugVariable.Ram_Mono:
                     return m_ramMonitor != null ? m_ramMonitor.MonoRam : 0;
 
+#if GRAPHY_BUILTIN_AUDIO
                 case DebugVariable.Audio_DB:
                     return m_audioMonitor != null ? m_audioMonitor.MaxDB : 0;
+#endif // GRAPHY_BUILTIN_AUDIO
 
                 default:
                     return 0;

--- a/Runtime/GraphyManager.cs
+++ b/Runtime/GraphyManager.cs
@@ -13,7 +13,11 @@
 
 using System;
 using UnityEngine;
+
+#if GRAPHY_BUILTIN_AUDIO
 using Tayx.Graphy.Audio;
+#endif // GRAPHY_BUILTIN_AUDIO
+
 using Tayx.Graphy.Fps;
 using Tayx.Graphy.Ram;
 using Tayx.Graphy.Utils;
@@ -158,6 +162,7 @@ namespace Tayx.Graphy
 
         [Range( 1, 200 )] [SerializeField] private int m_ramTextUpdateRate = 3; // 3 updates per sec.
 
+#if GRAPHY_BUILTIN_AUDIO
         // Audio -------------------------------------------------------------------------
 
         [SerializeField] private ModuleState m_audioModuleState = ModuleState.FULL;
@@ -177,6 +182,7 @@ namespace Tayx.Graphy
 
         [Tooltip( "Must be a power of 2 and between 64-8192" )] [SerializeField]
         private int m_spectrumSize = 512;
+#endif // GRAPHY_BUILTIN_AUDIO
 
         // Advanced ----------------------------------------------------------------------
 
@@ -196,12 +202,16 @@ namespace Tayx.Graphy
 
         private G_FpsManager m_fpsManager = null;
         private G_RamManager m_ramManager = null;
+#if GRAPHY_BUILTIN_AUDIO
         private G_AudioManager m_audioManager = null;
+#endif // GRAPHY_BUILTIN_AUDIO
         private G_AdvancedData m_advancedData = null;
 
         private G_FpsMonitor m_fpsMonitor = null;
         private G_RamMonitor m_ramMonitor = null;
+#if GRAPHY_BUILTIN_AUDIO
         private G_AudioMonitor m_audioMonitor = null;
+#endif // GRAPHY_BUILTIN_AUDIO
 
         private ModulePreset m_modulePresetState = ModulePreset.FPS_BASIC_ADVANCED_FULL;
 
@@ -251,7 +261,10 @@ namespace Tayx.Graphy
                 m_graphModulePosition = value;
                 m_fpsManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
                 m_ramManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
+
+#if GRAPHY_BUILTIN_AUDIO
                 m_audioManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
+#endif // GRAPHY_BUILTIN_AUDIO
             }
         }
 
@@ -417,6 +430,7 @@ namespace Tayx.Graphy
         public float ReservedRam => m_ramMonitor.ReservedRam;
         public float MonoRam => m_ramMonitor.MonoRam;
 
+#if GRAPHY_BUILTIN_AUDIO
         // Audio -------------------------------------------------------------------------
 
         // Setters & Getters
@@ -513,6 +527,7 @@ namespace Tayx.Graphy
         /// </summary>
         public float MaxDB => m_audioMonitor.MaxDB;
 
+#endif // GRAPHY_BUILTIN_AUDIO
 
         // Advanced ---------------------------------------------------------------------
 
@@ -588,7 +603,11 @@ namespace Tayx.Graphy
 
                     m_ramManager.SetPosition( modulePosition, m_graphModuleOffset );
                     m_fpsManager.SetPosition( modulePosition, m_graphModuleOffset );
+
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetPosition( modulePosition, m_graphModuleOffset );
+#endif // GRAPHY_BUILTIN_AUDIO
+
                     break;
 
                 case ModuleType.ADVANCED:
@@ -609,9 +628,11 @@ namespace Tayx.Graphy
                     m_ramManager.SetState( moduleState );
                     break;
 
+#if GRAPHY_BUILTIN_AUDIO
                 case ModuleType.AUDIO:
                     m_audioManager.SetState( moduleState );
                     break;
+#endif // GRAPHY_BUILTIN_AUDIO
 
                 case ModuleType.ADVANCED:
                     m_advancedData.SetState( moduleState );
@@ -642,84 +663,108 @@ namespace Tayx.Graphy
                 case ModulePreset.FPS_BASIC:
                     m_fpsManager.SetState( ModuleState.BASIC );
                     m_ramManager.SetState( ModuleState.OFF );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_TEXT:
                     m_fpsManager.SetState( ModuleState.TEXT );
                     m_ramManager.SetState( ModuleState.OFF );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.OFF );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_TEXT_RAM_TEXT:
                     m_fpsManager.SetState( ModuleState.TEXT );
                     m_ramManager.SetState( ModuleState.TEXT );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL_RAM_TEXT:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.TEXT );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL_RAM_FULL:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.FULL );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_TEXT_RAM_TEXT_AUDIO_TEXT:
                     m_fpsManager.SetState( ModuleState.TEXT );
                     m_ramManager.SetState( ModuleState.TEXT );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.TEXT );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL_RAM_TEXT_AUDIO_TEXT:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.TEXT );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.TEXT );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL_RAM_FULL_AUDIO_TEXT:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.FULL );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.TEXT );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL_RAM_FULL_AUDIO_FULL:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.FULL );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.FULL );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.OFF );
                     break;
 
                 case ModulePreset.FPS_FULL_RAM_FULL_AUDIO_FULL_ADVANCED_FULL:
                     m_fpsManager.SetState( ModuleState.FULL );
                     m_ramManager.SetState( ModuleState.FULL );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.FULL );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.FULL );
                     break;
 
                 case ModulePreset.FPS_BASIC_ADVANCED_FULL:
                     m_fpsManager.SetState( ModuleState.BASIC );
                     m_ramManager.SetState( ModuleState.OFF );
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.SetState( ModuleState.FULL );
                     break;
 
@@ -749,7 +794,9 @@ namespace Tayx.Graphy
                 {
                     m_fpsManager.RestorePreviousState();
                     m_ramManager.RestorePreviousState();
+#if GRAPHY_BUILTIN_AUDIO
                     m_audioManager.RestorePreviousState();
+#endif // GRAPHY_BUILTIN_AUDIO
                     m_advancedData.RestorePreviousState();
 
                     m_active = true;
@@ -767,7 +814,9 @@ namespace Tayx.Graphy
             {
                 m_fpsManager.SetState( ModuleState.OFF );
                 m_ramManager.SetState( ModuleState.OFF );
+#if GRAPHY_BUILTIN_AUDIO
                 m_audioManager.SetState( ModuleState.OFF );
+#endif // GRAPHY_BUILTIN_AUDIO
                 m_advancedData.SetState( ModuleState.OFF );
 
                 m_active = false;
@@ -787,22 +836,27 @@ namespace Tayx.Graphy
 
             m_fpsMonitor = GetComponentInChildren<G_FpsMonitor>( true );
             m_ramMonitor = GetComponentInChildren<G_RamMonitor>( true );
+#if GRAPHY_BUILTIN_AUDIO
             m_audioMonitor = GetComponentInChildren<G_AudioMonitor>( true );
+#endif // GRAPHY_BUILTIN_AUDIO
 
             m_fpsManager = GetComponentInChildren<G_FpsManager>( true );
             m_ramManager = GetComponentInChildren<G_RamManager>( true );
-            m_audioManager = GetComponentInChildren<G_AudioManager>( true );
             m_advancedData = GetComponentInChildren<G_AdvancedData>( true );
 
             m_fpsManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
             m_ramManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
-            m_audioManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
             m_advancedData.SetPosition( m_advancedModulePosition, m_advancedModuleOffset );
 
             m_fpsManager.SetState( m_fpsModuleState );
             m_ramManager.SetState( m_ramModuleState );
-            m_audioManager.SetState( m_audioModuleState );
             m_advancedData.SetState( m_advancedModuleState );
+
+#if GRAPHY_BUILTIN_AUDIO
+            m_audioManager = GetComponentInChildren<G_AudioManager>( true );
+            m_audioManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
+            m_audioManager.SetState( m_audioModuleState );
+#endif // GRAPHY_BUILTIN_AUDIO
 
             if( !m_enableOnStartup )
             {
@@ -822,13 +876,16 @@ namespace Tayx.Graphy
             {
                 m_fpsManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
                 m_ramManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
-                m_audioManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
                 m_advancedData.SetPosition( m_advancedModulePosition, m_advancedModuleOffset );
 
                 m_fpsManager.SetState( m_fpsModuleState );
                 m_ramManager.SetState( m_ramModuleState );
-                m_audioManager.SetState( m_audioModuleState );
                 m_advancedData.SetState( m_advancedModuleState );
+
+#if GRAPHY_BUILTIN_AUDIO
+                m_audioManager.SetPosition( m_graphModulePosition, m_graphModuleOffset );
+                m_audioManager.SetState( m_audioModuleState );
+#endif // GRAPHY_BUILTIN_AUDIO
             }
         }
 
@@ -1056,7 +1113,9 @@ namespace Tayx.Graphy
         {
             m_fpsManager.UpdateParameters();
             m_ramManager.UpdateParameters();
+#if GRAPHY_BUILTIN_AUDIO
             m_audioManager.UpdateParameters();
+#endif // GRAPHY_BUILTIN_AUDIO
             m_advancedData.UpdateParameters();
         }
 
@@ -1064,7 +1123,9 @@ namespace Tayx.Graphy
         {
             m_fpsManager.RefreshParameters();
             m_ramManager.RefreshParameters();
+#if GRAPHY_BUILTIN_AUDIO
             m_audioManager.RefreshParameters();
+#endif // GRAPHY_BUILTIN_AUDIO
             m_advancedData.RefreshParameters();
         }
 

--- a/Runtime/Tayx.Graphy.asmdef
+++ b/Runtime/Tayx.Graphy.asmdef
@@ -20,6 +20,11 @@
             "name": "com.unity.modules.xr",
             "expression": "",
             "define": "GRAPHY_XR"
+        },
+        {
+            "name": "com.unity.modules.audio",
+            "expression": "",
+            "define": "GRAPHY_BUILTIN_AUDIO"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Hey! So I'm using FMOD in my project and wanted to try out Graphy as well, but I also want to disable the built-in Unity audio module. I got errors when I did that because the code depended on it. So, here's one way of solving the issue using conditional compilation, letting users disable the built-in audio module and excluding all audio-related code.

This doesn't touch the prefab files so the audio-related fields are still serialized in them, which means if the developer decides to re-enable the audio module, they get those fields back (at least for the prefabs inside the package).

Thanks!