### PR TITLE
faster percentile updates

### DIFF
--- a/Runtime/Util/G_DoubleEndedQueue.cs
+++ b/Runtime/Util/G_DoubleEndedQueue.cs
@@ -1,0 +1,198 @@
+/* ---------------------------------------
+ * Author:          Paul Sinnett (paul.sinnett@gmail.com) (@paulsinnett)
+ * Contributors:    https://github.com/Tayx94/graphy/graphs/contributors
+ * Project:         Graphy - Ultimate Stats Monitor
+ * Date:            06-Sep-24
+ * Studio:          Powered Up Games
+ *
+ * Git repo:        https://github.com/Tayx94/graphy
+ *
+ * This project is released under the MIT license.
+ * Attribution is not required, but it is always welcomed!
+ * -------------------------------------*/
+
+using UnityEngine.Assertions;
+
+namespace Tayx.Graphy.Utils
+{
+    public class G_DoubleEndedQueue
+    {
+        #region Variables -> Private
+
+        /// <summary>
+        /// Fixed size array for holding the values.
+        /// </summary>
+        private short[] m_values;
+
+        /// <summary>
+        /// Index of the head element.
+        /// </summary>
+        private short m_head;
+
+        /// <summary>
+        /// Index of the entry after the tail element.
+        /// </summary>
+        private short m_tail;
+
+        /// <summary>
+        /// Number of items in the queue.
+        /// </summary>
+        private short m_count;
+
+        /// <summary>
+        /// Programming error messages for assert failures.
+        /// </summary>
+        private const string m_errorEmpty = "queue is empty";
+        private const string m_errorFull = "queue is full";
+
+        #endregion
+
+        #region Properties -> Public
+
+        /// <summary>
+        /// The current number of items in the queue.
+        /// </summary>
+        public short Count => m_count;
+
+        /// <summary>
+        /// True if the queue is currently at full capacity.
+        /// </summary>
+        public bool Full => m_count == m_values.Length;
+
+        #endregion
+
+        #region Methods -> Public
+
+        /// <summary>
+        /// Construct a queue.
+        /// </summary>
+        /// <param name="capacity">
+        /// Maximum number of values in the queue.
+        /// </param>
+        public G_DoubleEndedQueue( short capacity )
+        {
+            m_values = new short[ capacity ];
+            m_head = 0;
+            m_tail = 0;
+            m_count = 0;
+        }
+
+        /// <summary>
+        /// Clear the content of the queue, O(1).
+        /// </summary>
+        public void Clear()
+        {
+            m_head = 0;
+            m_tail = 0;
+            m_count = 0;
+        }
+
+        /// <summary>
+        /// Add a value to the front of the queue, O(1).
+        /// Asserts that the queue is not already full.
+        /// </summary>
+        /// <param name="value">
+        /// The value of the entry.
+        /// </param>
+        public void PushFront( short value )
+        {
+            AssertNotFull();
+            m_head = Previous( m_head );
+            m_values[ m_head ] = value;
+            m_count++;
+        }
+
+        /// <summary>
+        /// Add a value to the back of the queue, O(1).
+        /// Asserts that the queue is not already full.
+        /// </summary>
+        /// <param name="value">
+        /// The value of the entry.
+        /// </param>
+        public void PushBack( short value )
+        {
+            AssertNotFull();
+            m_values[ m_tail ] = value;
+            m_tail = Next( m_tail );
+            m_count++;
+        }
+
+        /// <summary>
+        /// Removes the value at the front of the queue, O(1).
+        /// Asserts that the queue is not empty.
+        /// </summary>
+        /// <returns>the removed value</returns>
+        public short PopFront()
+        {
+            AssertNotEmpty();
+            short value = m_values[ m_head ];
+            m_head = Next( m_head );
+            m_count--;
+            return value;
+        }
+
+        /// <summary>
+        /// Removes the value at the back of the queue, O(1).
+        /// Asserts that the queue is not empty.
+        /// </summary>
+        /// <returns>the removed value</returns>
+        public short PopBack()
+        {
+            AssertNotEmpty();
+            m_tail = Previous( m_tail );
+            short value = m_values[ m_tail ];
+            m_count--;
+            return value;
+        }
+
+        /// <summary>
+        /// Returns the value at the front of the queue, O(1).
+        /// Asserts that the queue is not empty.
+        /// </summary>
+        /// <returns>the value at the front of the queue</returns>
+        public short PeekFront()
+        {
+            AssertNotEmpty();
+            return m_values[ m_head ];
+        }
+
+        /// <summary>
+        /// Returns the value at the back of the queue, O(1).
+        /// Asserts that the queue is not empty.
+        /// </summary>
+        /// <returns>the value at the back of the queue</returns>
+        public short PeekBack()
+        {
+            AssertNotEmpty();
+            return m_values[ Previous( m_tail ) ];
+        }
+
+        #endregion
+
+        #region Methods -> Private
+
+        void AssertNotEmpty()
+        {
+            Assert.IsTrue( m_count > 0, m_errorEmpty );
+        }
+
+        void AssertNotFull()
+        {
+            Assert.IsTrue( m_count < m_values.Length, m_errorFull );
+        }
+
+        short LastIndex => (short) ( m_values.Length - 1 );
+        
+        short Next( short index )
+        {
+            return (short) ( index < LastIndex? index + 1 : 0 );
+        }
+
+        short Previous( short index )
+        {
+            return (short) ( index > 0? index - 1 : LastIndex );
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/Util/G_DoubleEndedQueue.cs.meta
+++ b/Runtime/Util/G_DoubleEndedQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cee3527c9744c54d858a52fe3b80a32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Util/G_Histogram.cs
+++ b/Runtime/Util/G_Histogram.cs
@@ -1,0 +1,158 @@
+/* ---------------------------------------
+ * Author:          Paul Sinnett (paul.sinnett@gmail.com) (@paulsinnett)
+ * Contributors:    https://github.com/Tayx94/graphy/graphs/contributors
+ * Project:         Graphy - Ultimate Stats Monitor
+ * Date:            06-Sep-24
+ * Studio:          Powered Up Games
+ *
+ * Git repo:        https://github.com/Tayx94/graphy
+ *
+ * This project is released under the MIT license.
+ * Attribution is not required, but it is always welcomed!
+ * -------------------------------------*/
+
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace Tayx.Graphy.Utils
+{
+    public class G_Histogram
+    {
+        #region Variables -> Private
+
+        /// <summary>
+        /// Fixed size array for holding the histogram values.
+        /// </summary>
+        private SortedList<short, short> m_histogram;
+
+        /// <summary>
+        /// Total number of data points in the histogram.
+        /// </summary>
+        private short m_count;
+
+        /// <summary>
+        /// Minimum limit for histogram values. Values below this limit
+        /// will be clamped to this value.
+        private short m_minimum;
+
+        /// <summary>
+        /// Maximum limit for histogram values. Values above this limit
+        /// will be clamped to this value.
+        private short m_maximum;
+
+        /// <summary>
+        /// Programming error messages for assert failures.
+        /// </summary>
+        private const string m_errorMinimumLessThanMaximum = "minimum must be less than maximum";
+        private const string m_errorSampleNotFound = "sample not found";
+        private const string m_errorOutputArrayTooSmall = "output array too small";
+        private const string m_errorNotEnoughData = "not enough data in histogram";
+
+        #endregion
+
+        #region Methods -> Public
+
+        /// <summary>
+        /// Construct a histogram.
+        /// </summary>
+        /// <param name="minimum">
+        /// Values added below this value will be clamped.
+        /// </param>
+        /// <param name="maximum">
+        /// Values added above this value will be clamped.
+        /// </param>
+        public G_Histogram( short minimum, short maximum )
+        {
+            Assert.IsTrue( minimum < maximum, m_errorMinimumLessThanMaximum );
+            m_histogram = new SortedList<short, short>( maximum - minimum );
+            m_minimum = minimum;
+            m_maximum = maximum;
+            m_count = 0;
+        }
+
+        /// <summary>
+        /// Add a sample to the histogram, O(log₂ n) where n is the
+        /// number of distinct sample entries.
+        /// </summary>
+        /// <param name="sample">
+        /// The sample to add to this histogram.
+        /// </param>
+        public void AddSample( short sample )
+        {
+            sample = (short) Mathf.Clamp( sample, m_minimum, m_maximum );
+            if( m_histogram.ContainsKey( sample ) )
+            {
+                m_histogram[ sample ]++;
+            }
+            else
+            {
+                m_histogram.Add( sample, 1 );
+            }
+            m_count++;
+        }
+
+        /// <summary>
+        /// Remove a sample from the histogram, O(log₂ n) where n is the
+        /// number of distinct sample values.
+        /// </summary>
+        /// <param name="sample">
+        /// The sample to remove.
+        /// </param>
+        public void RemoveSample( short sample )
+        {
+            sample = (short) Mathf.Clamp( sample, m_minimum, m_maximum );
+            Assert.IsTrue( m_histogram.ContainsKey( sample ), m_errorSampleNotFound );
+            m_histogram[ sample ]--;
+            if( m_histogram[ sample ] == 0 )
+            {
+                m_histogram.Remove( sample );
+            }
+            m_count--;
+        }
+
+        /// <summary>
+        /// Write out the required number of samples in order from lowest
+        /// to the highest, O(n) where n is the count of samples to write
+        /// out.
+        /// </summary>
+        /// <param name="output">
+        /// An array to write into.
+        /// </param>
+        /// <param name="count">
+        /// The number of samples to write out.
+        /// </param>
+        public void WriteToSortedArray( short[] output, int count )
+        {
+            Assert.IsTrue( count <= output.Length, m_errorOutputArrayTooSmall );
+            Assert.IsTrue( count <= m_count, m_errorNotEnoughData );
+
+            int index = 0;
+            var keys = m_histogram.Keys;
+            var values = m_histogram.Values;
+            int entries = keys.Count;
+            for( short entry = 0; entry < entries && index < count; entry++ )
+            {
+                short sample = keys[ entry ];
+                int instances = values[ entry ];
+                for( int i = 0; i < instances && index < count; i++ )
+                {
+                    output[ index ] = sample;
+                    index++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clear the histogram, O(n) where n is the number of entries
+        /// in the histogram.
+        /// </summary>
+        public void Clear()
+        {
+            m_histogram.Clear();
+            m_count = 0;
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/Util/G_Histogram.cs.meta
+++ b/Runtime/Util/G_Histogram.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37599e96045db254aac69d2eace4d109
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The sorted array used to calculate the 1% and 0.1% lows is generated from a histogram. This is an O(n) operation where n is the number of entries in 1% of sample buffer rather than the entire buffer. The histogram itself is implemented with a `SortedList`. Values are added and removed by maintaining the buffer as a double ended queue. Since this can also be used to calculate the average each frame without having to re-sum all the values, I have hooked that in as well. I have also adjusted the calculation of the quantiles to more accurately reflect the statistics.

Profiling this change on a test project in the Unity profile window, the `G_FpsMonitor` update goes from ~0.03 ms per frame to <0.01 ms per frame.