### PR TITLE
Fix Advanced Module offset reset on parameter refresh

### DIFF
--- a/Runtime/Advanced/G_AdvancedData.cs
+++ b/Runtime/Advanced/G_AdvancedData.cs
@@ -268,7 +268,7 @@ namespace Tayx.Graphy.Advanced
                 image.color = m_graphyManager.BackgroundColor;
             }
 
-            SetPosition( m_graphyManager.AdvancedModulePosition, Vector2.zero );
+            SetPosition( m_graphyManager.AdvancedModulePosition, m_graphyManager.AdvancedModuleOffset );
             SetState( m_graphyManager.AdvancedModuleState );
         }
 
@@ -279,7 +279,7 @@ namespace Tayx.Graphy.Advanced
                 image.color = m_graphyManager.BackgroundColor;
             }
 
-            SetPosition( m_graphyManager.AdvancedModulePosition, Vector2.zero );
+            SetPosition( m_graphyManager.AdvancedModulePosition, m_graphyManager.AdvancedModuleOffset );
             SetState( m_currentModuleState, true );
         }
 

--- a/Runtime/GraphyManager.cs
+++ b/Runtime/GraphyManager.cs
@@ -538,6 +538,8 @@ namespace Tayx.Graphy
             }
         }
 
+        public Vector2 AdvancedModuleOffset => m_advancedModuleOffset;
+
         #endregion
 
         #region Methods -> Unity Callbacks
@@ -592,7 +594,7 @@ namespace Tayx.Graphy
                     break;
 
                 case ModuleType.ADVANCED:
-                    m_advancedData.SetPosition( modulePosition, Vector2.zero );
+                    m_advancedData.SetPosition( modulePosition, m_advancedModuleOffset );
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- `m_advancedModuleOffset` was only applied via the `AdvancedModulePosition` setter. Three other call sites passed `Vector2.zero`, wiping the configured X/Y offset on state toggles, focus changes, and parameter refreshes — so the Advanced Module would appear at the correct position on boot but snap back to the corner origin on any internal event.
- Added a public `AdvancedModuleOffset` getter on `GraphyManager` (the field was private with no accessor) and replaced the three hardcoded `Vector2.zero` arguments with the serialized offset.

## Changes
- `Runtime/GraphyManager.cs` — add `AdvancedModuleOffset` getter; fix `SetModulePosition(ModuleType.ADVANCED, …)`.
- `Runtime/Advanced/G_AdvancedData.cs` — fix `UpdateParameters()` and `RefreshParameters()`.

## Test plan
- [ ] Set `m_advancedModuleOffset` to a non-zero value in the inspector.
- [ ] Enter Play mode — verify the Advanced Module renders at the configured offset.
- [ ] Toggle module state (F1 by default) — position retained.
- [ ] Change module mode via `SetModuleMode` from a script — position retained.
- [ ] Alt-tab out and back (focus loss / gain) — position retained.
- [ ] Confirm FPS / RAM / Audio offsets (driven by `m_graphModuleOffset`) continue to behave correctly — their code path was not touched.